### PR TITLE
Create sergei_torch_measure.py

### DIFF
--- a/Optimizer/sergei_torch_measure.py
+++ b/Optimizer/sergei_torch_measure.py
@@ -1,0 +1,102 @@
+import numpy as np
+import torch
+from torch import nn
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+class TorchMeasure(nn.Module):
+    def __init__(self, locations, weights, optimize_locations = False):
+        super(TorchMeasure, self).__init__()
+        assert len(locations) == len(weights), 'locations and weights should have the same length!'
+        if not optimize_locations:
+            self.locations = torch.tensor(locations)
+        else:
+            self.locations = torch.tensor(locations, dtype=torch.float64, requires_grad=True)
+        self.weights = torch.tensor(weights, dtype=torch.float64, requires_grad=True)
+        self.n = len(weights)
+
+    def __str__(self):
+        out = 'locations weights\n'
+        for i in range(self.n):
+            out += f'{self.locations[i].item()}      {self.weights[i].item()}\n'
+        return out
+
+    def __repr__(self):
+        out = 'locations weights\n'
+        for i in range(self.n):
+            out += f'{self.locations[i].item()}      {self.weights[i].item(): 0.6f}\n'
+        return out
+
+    def total_variation(self):
+        """ Total variation of the measure"""
+        return float(torch.abs(self.weights).sum())
+
+    def total_mass(self):
+        """ Total mass of the measure"""
+        return float(self.weights.sum())
+
+    def support(self, tol_supp=1e-12):
+        """ Support of the measure up to tol_supp tolerance of what is considered as 0 """
+        tol = self.total_variation() * tol_supp
+        return np.arange(self.n)[torch.abs(self.weights) > tol]
+
+    def is_positive(self, tol_pos=1e-6):
+        """ Check if the measure is non-negative"""
+        tol = self.total_variation() * tol_pos
+        return bool(torch.all(self.weights >= -tol))
+
+    def is_probability(self, tol=1e-6):
+        """ Check whether this is probability measure """
+        return self.is_positive() and np.abs(self.total_mass() - 1) <= tol
+
+    def copy(self):
+        """ Create a copy of the measure"""
+        return TorchMeasure(self.locations.detach().numpy(), self.weights.detach().numpy())
+
+    def sample_from(self, nmb):
+        """ sample n locations from probability distribution proportional to the measure """
+        assert self.is_positive(), 'measure should be positive to sample from it!'
+        cdf = np.cumsum(self.weights.detach().numpy())/self.total_mass()
+        sample = []
+        for i in range(nmb):
+            sample.append(self.locations.detach().numpy()[cdf > np.random.random()][0]) # inverse of the cdf method
+        return np.array(sample)
+
+    def put_mass(self, grad: torch.Tensor, epsilon: float):
+        """ Put mass epsilon to the coordinate of weights where grad is minimal """
+        with torch.no_grad():
+            self.weights[grad.argmin()] += epsilon
+        ## without "with" above autograd gets confused when tensor with gradient is changed in place
+        # see https://medium.com/@mrityu.jha/understanding-the-grad-of-autograd-fc8d266fd6cf
+
+
+    def take_mass(self, grad: torch.Tensor, epsilon: float):
+        """ Take mass epsilon from the coordinates of weights where grad is maximal starting from the maximal, next to maximal etc """
+        decreasing_grad_idx = torch.flip(grad.argsort(), dims=[0])
+        mass_left = epsilon
+        with torch.no_grad():
+            for idx in decreasing_grad_idx:
+                self.weights[idx] -= mass_left
+                if self.weights[idx] < 0.:
+                    mass_left = -self.weights[idx]
+                    self.weights[idx] = 0.
+                else:
+                    break
+
+    def take_step(self, grad: torch.Tensor, epsilon: float, silent=True):
+        """ true gradient descent  preserving the total mass of weights"""
+        self.put_mass(grad, epsilon)
+        self.take_mass(grad, epsilon)
+        if not silent:
+            return print(self)
+
+    def stop_criterion(self, grad, tol_supp=1e-6, tol_const=1e-3, adaptive=False):
+        """
+        Grad should be minimal and constant on the support of the measure.
+        Consider it to be a constant if it varies by less than tol_const.
+        If adaptive = True, if it varies less than tol_const * (range of grad)
+        """
+        min_grad, max_grad = grad.min(), grad.max()
+        if adaptive:
+            tol_const *= (max_grad - min_grad)
+        return bool(grad[self.support(tol_supp)].max() - min_grad < tol_const)


### PR DESCRIPTION
Guys, great work!
Looks more professional than my variant in many places. A few notes:
1. Locations are usually not optimised, so I set it as an option
2. __str__ - vertical layout is better (see my version)
3. I have an extra option in support: one may want to ignore very small atoms
4. positive and negative parts are also measures, just the negative masses (respectively, negative) are set to 0 and negative masses are reversed. Then you have mu = mu^+ - mu^- for a signed measure
5. put_mass and take mass. Great that you discovered you need to use  with torch.no_grad! It took me some time. Your version takes mass from only one atom returning what mass is yet left to take out of lr/2. It should continue to take all lr/2 mass from the atoms with next maximal vales of the gradient. See my version. I also suggest white lr instead of lr/2 - we will be making steps of `size' (the total variation of the increment measure)  2*lr -  does not really matter.
6. Move 'step' to a different class: this is really already a minimisation algorithm, not really a measure stuff
(see my code and adjust yours respectively)
7. I like your sample function! It's better than my realisation! But assure the measure is positive first (your example gives error, when you try to sample from a non-positive measure c)
8. I like visualize, but also add a grey 0-line to the plot

Overall, great! Continue with optimisation using this algorithm now 